### PR TITLE
Patch net-ssh for newer RHEL / AlmaLinux versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,12 @@ ARG CHEF_LICENSE=accept
 # Set any build variables here
 ARG VAGRANT_VERSION=2.2.19
 
+ARG VAGRANT_GEMDIR=/opt/vagrant/embedded/gems/${VAGRANT_VERSION}/
+ARG CHEF_GEMDIR=/opt/chef-workstation/embedded/lib/ruby/gems/3.0.0/
+
+ARG NET_SSH_PATCH1=f79ed49dc068317fb280bd2fb554ecb0ce13a7e1 
+ARG NET_SSH_PATCH2=a45f54fe1de434605af0b7195dd9a91bccd2cec5"
+
 # Print Chef-Workstation component versions
 RUN /opt/chef-workstation/bin/chef -v
 
@@ -15,6 +21,7 @@ RUN echo "Installing dependencies..." \
  && apt-get -qq install --no-install-recommends -y \
         build-essential \
         unzip \
+        patchutils \
  && apt-get clean \
  && rm -rf /tmp/* /var/cache/debconf/*-old /var/lib/apt/lists/* \
         /var/lib/dpkg/*-old /var/log/*log /var/log/apt/* /var/tmp/*
@@ -31,6 +38,23 @@ RUN echo "Installing vagrant ${VAGRANT_VERSION}..." \
 RUN echo "Monkey patching Berkshelf (see https://github.com/berkshelf/berkshelf/pull/1827)..." \
  && sed -i -e 's/Berkshelf.formatter.skipping(cookbook, connection)/Berkshelf.formatter.skipping(cookbook, connection)\nrescue Net::HTTPClientException => e\nputs e.response.body/' \
         /opt/chef-workstation/embedded/lib/ruby/gems/*/gems/berkshelf-*/lib/berkshelf/uploader.rb
+
+# Enterprise Linux 9 (RHEL/AlmaLinux/Rocky) ship with ssh-rsa signatures disabled.
+# For more details see https://www.openssh.com/txt/release-8.7
+#
+# The ruby gem net-ssh needs to be updated to 6.3.0.beta1 + patch to handle this.
+# Future releases of test-kitchen and vagrant will probably handle this better.
+RUN /opt/vagrant/embedded/bin/gem install net-ssh -v 6.3.0.beta1 --pre --install-dir ${VAGRANT_GEMDIR} && \
+    /opt/chef-workstation/embedded/bin/gem install net-ssh -v 6.3.0.beta1 --pre --no-user-install  --install-dir ${CHEF_GEMDIR} && \
+    sed -i 's/gem "net-ssh", "= 6.1.0"/gem "net-ssh", "= 6.3.0.beta1"/' /opt/chef-workstation/bin/kitchen && \
+    curl https://github.com/net-ssh/net-ssh/commit/${NET_SSH_PATCH1}.diff | filterdiff -p1 -x 'test/*' -x '.rubocop_todo.yml' | \
+      patch -p1 -d ${VAGRANT_GEMDIR}/gems/net-ssh-6.3.0.beta1 && \
+    curl https://github.com/net-ssh/net-ssh/commit/${NET_SSH_PATCH2}.diff | filterdiff -p1 -x 'test/*' -x '.rubocop_todo.yml' | \
+      patch -p1 -d ${VAGRANT_GEMDIR}/gems/net-ssh-6.3.0.beta1 && \
+    curl https://github.com/net-ssh/net-ssh/commit/${NET_SSH_PATCH1}.diff | filterdiff -p1 -x 'test/*' -x '.rubocop_todo.yml' | \
+      patch -p1 -d ${CHEF_GEMDIR}/gems/net-ssh-6.3.0.beta1 && \
+    curl https://github.com/net-ssh/net-ssh/commit/${NET_SSH_PATCH2}.diff | filterdiff -p1 -x 'test/*' -x '.rubocop_todo.yml' | \
+      patch -p1 -d ${CHEF_GEMDIR}/gems/net-ssh-6.3.0.beta1
 
 # Create directory and install knife-spork for cookbook deployment
 RUN mkdir -p ~/environments \

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ ARG VAGRANT_GEMDIR=/opt/vagrant/embedded/gems/${VAGRANT_VERSION}/
 ARG CHEF_GEMDIR=/opt/chef-workstation/embedded/lib/ruby/gems/3.0.0/
 
 ARG NET_SSH_PATCH1=f79ed49dc068317fb280bd2fb554ecb0ce13a7e1 
-ARG NET_SSH_PATCH2=a45f54fe1de434605af0b7195dd9a91bccd2cec5"
+ARG NET_SSH_PATCH2=a45f54fe1de434605af0b7195dd9a91bccd2cec5
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
-FROM chef/chefworkstation:21.9.634
+FROM chef/chefworkstation:22.7.1007
 
 # Accept the license without prompting
 ARG CHEF_LICENSE=accept
 
 # Set any build variables here
-ARG VAGRANT_VERSION=2.2.18
+ARG VAGRANT_VERSION=2.2.19
 
 # Print Chef-Workstation component versions
 RUN /opt/chef-workstation/bin/chef -v

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,8 @@ ARG CHEF_GEMDIR=/opt/chef-workstation/embedded/lib/ruby/gems/3.0.0/
 ARG NET_SSH_PATCH1=f79ed49dc068317fb280bd2fb554ecb0ce13a7e1 
 ARG NET_SSH_PATCH2=a45f54fe1de434605af0b7195dd9a91bccd2cec5"
 
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
 # Print Chef-Workstation component versions
 RUN /opt/chef-workstation/bin/chef -v
 


### PR DESCRIPTION
The net-ssh ruby gem needs patches to support newer openssh in RHEL9 / AlmaLinux 9.